### PR TITLE
Clarify migration of registry on Nectar hardware

### DIFF
--- a/plenary-2021-12-02.md
+++ b/plenary-2021-12-02.md
@@ -55,7 +55,7 @@
 
 *No action items
 * Armin not yet sent MoU to ANU. To meet with co-chairs to 
-* New catalogue service working, i.e., transitioned to ARDC, but DNS entries may not be updated until later today as they have just been setup before the meeting
+* Catalogue service migrated to a new Nectar (ARDC) environment, but DNS entries may not be updated until later today as they have just been setup before the meeting
 
 
 #### 5. Description of conceptual BDR Linked Data Design


### PR DESCRIPTION
Clarify the description of the migration that happened to the
registry (a.k.a. catalogue) service. It was a migration of the
existing system from one Nectar environment to another; it wasn't
the migration of the service into ARDC control.